### PR TITLE
Add --config argument, update readme and add/update docker setup files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-  FROM python:3.9-alpine
-  RUN apk --no-cache add git
-  RUN pip3 install paho-mqtt
-  RUN git clone https://github.com/zivillian/enverproxy.git /data/app
-  RUN sed -i "s|/etc/enverproxy.conf|/data/app/enverproxy.conf|g" /data/app/enverproxy.py 
-  RUN sed -i "s|mqtthost     = localhost|mqtthost     = 192.168.8.21|g" /data/app/enverproxy.conf
-  RUN sed -i "s|verbosity   = 5|verbosity   = 2|g" /data/app/enverproxy.conf
-  WORKDIR /data/app
-  EXPOSE 1898
-  CMD ["./enverproxy.py"]
-  ENTRYPOINT ["python3"]
+FROM python:alpine
+
+RUN apk --no-cache add git && pip3 install paho-mqtt
+
+RUN git clone https://github.com/zivillian/enverproxy.git /data/app
+RUN sed -i "s|/etc/enverproxy.conf|/data/app/enverproxy.conf|g" /data/app/enverproxy.py 
+
+WORKDIR /data/app
+VOLUME /data/app
+
+EXPOSE 1898
+
+CMD ["python3", "./enverproxy.py"]

--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ Using this python script, you can decode the traffic between your envertech EVB2
 ### Receiving side
 
 Clone this repo on a linux machine at `/opt/enverproxy` and configure it as a [systemd unit](enverproxy.service). Copy and update the config at [/etc/enverproxy.conf](enverproxy.conf) to your needs.
+Requires `paho-mqtt`. You can install it via `pip3 install paho-mqtt`
 
 ### EVB202
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.3'
+services:
+    enverproxy:
+        restart: unless-stopped
+        build: .
+        ports:
+            - '1898:1898'
+        container_name: enverproxy
+        volumes:
+            - './enverproxy.conf:/data/app/enverproxy.conf:ro'
+            - '/etc/localtime:/etc/localtime:ro'
+        healthcheck:
+            test: ["CMD-SHELL", "netstat -ltn | grep -c 1898 || exit 1"]

--- a/enverproxy.py
+++ b/enverproxy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # This is a simple port-forward / proxy for EnvertecBridge
 
+import argparse
 import ast
 import configparser
 import errno
@@ -16,9 +17,13 @@ import time
 from datetime import datetime
 from slog import slog
 
+argparser = argparse.ArgumentParser("Enverproxy");
+argparser.add_argument("--config", help="Path to config.", type=str, default="/etc/enverproxy.conf")
+args = argparser.parse_args()
+
 config = configparser.ConfigParser()
 config['internal']={}
-config['internal']['conf_file'] = '/etc/enverproxy.conf'
+config['internal']['conf_file'] = args.config
 config['internal']['section']   = 'enverproxy'
 config['internal']['version']   = '1.3'
 config['internal']['keys']      = "['buffer_size', 'delay', 'listen_port', 'verbosity', 'log_type', 'log_address', 'log_port', 'forward_IP', 'forward_port', 'mqttuser', 'mqttpassword', 'mqtthost', 'mqttport']"


### PR DESCRIPTION
This PR includes a `--config` parameter to change the config file path, an update to the readme to explain how to install `paho-mqtt` and updated docker files.