### PR TITLE
fix(paho-mqtt): make it work with V2

### DIFF
--- a/enverproxy.py
+++ b/enverproxy.py
@@ -68,7 +68,7 @@ class TheServer:
         self.server.listen(200)
 
     def connect_mqtt(self, host, user, password, port):
-        self.mqtt = mqtt.Client('enverproxy')
+        self.mqtt = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id='enverproxy')
         if (user != None or password != None):
             self.mqtt.username_pw_set(user, password)
         self.mqtt.connect(host, port)

--- a/enverproxy.py
+++ b/enverproxy.py
@@ -68,7 +68,7 @@ class TheServer:
         self.server.listen(200)
 
     def connect_mqtt(self, host, user, password, port):
-        self.mqtt = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id='enverproxy')
+        self.mqtt = mqtt.Client(callback_api_version=mqtt.CallbackAPIVersion.VERSION1, client_id='enverproxy')
         if (user != None or password != None):
             self.mqtt.username_pw_set(user, password)
         self.mqtt.connect(host, port)


### PR DESCRIPTION
Hi @zivillian,

due to the latest major version update of [`paho-mqtt`](https://github.com/eclipse/paho.mqtt.python/blob/master/docs/migrations.rst#versioned-the-user-callbacks) it is now required to provide the callback API version while initiating the MQTT Client.  I therefore updated your code accordingly.

[see `paho-mqtt` documentation](https://github.com/eclipse/paho.mqtt.python/blob/master/docs/migrations.rst#versioned-the-user-callbacks)
```
# OLD code
>>> mqttc = mqtt.Client()

# NEW code
>>> mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1)
```

Best,
Timo