### PR TITLE
Support for EVT800

### DIFF
--- a/enverproxy.py
+++ b/enverproxy.py
@@ -253,7 +253,7 @@ class TheServer:
                 self.__log.logMsg('Reply sent to: ' + str(self.s), 3)
                 data = json.dumps({"ip":self.s.getpeername()[0], "last_seen":datetime.utcnow().isoformat()})
                 self.mqtt.publish('enverbridge/bridge', data)
-            elif data[:6].hex() == '6803d6681004':
+            elif data[:6].hex() in ['6803d6681004', '680056681004']:
                 # payload from converter
                 self.process_data(data)
             else:

--- a/enverproxy.py
+++ b/enverproxy.py
@@ -211,7 +211,7 @@ class TheServer:
         datainhex = data.hex()
         wr = []
         wr_index = 0
-        wr_index_max = 20
+        wr_index_max = ((len(datainhex)-40)//64)
         self.__log.logMsg("Processing Data", 5)
         while True:
             response = self.extract(datainhex, wr_index)


### PR DESCRIPTION
The Envertech EVT800 has a other cmd id in the data.hex string:  `680056681004`.

```diff
--- a/enverproxy.py
+++ b/enverproxy.py
@@ -253,7 +253,7 @@ class TheServer:
                 self.__log.logMsg('Reply sent to: ' + str(self.s), 3)
                 data = json.dumps({"ip":self.s.getpeername()[0], "last_seen":datetime.utcnow().isoformat()})
                 self.mqtt.publish('enverbridge/bridge', data)
-            elif data[:6].hex() == '6803d6681004':
+            elif data[:6].hex() in ['6803d6681004', '680056681004']:
                 # payload from converter
                 self.process_data(data)
             else:
```
Additionally the _extract_ function breaks because of an empty string. Calculating wr_index_max out of the length fixes that problem:
```diff
--- a/enverproxy.py
+++ b/enverproxy.py
@@ -211,7 +211,7 @@ class TheServer:
         datainhex = data.hex()
         wr = []
         wr_index = 0
-        wr_index_max = 20
+        wr_index_max = ((len(datainhex)-40)//64)
         self.__log.logMsg("Processing Data", 5)
         while True:
             if len(datainhex) > (40+64+64*wr_index):
```

Tested with docker and the Envertech EVT800 with wifi, _Network Parameters setting_ to _TCP-Client_ and the Server Address is set to the docker host. 

Fixes https://github.com/zivillian/enverproxy/issues/9